### PR TITLE
Add licenses of used libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Um die App selbst zu Compilen sind folgende Pakete notwendig:
 Mitmachen ist erwünscht ;)
 	
 	
+	
+	
+	
+	
+	
 	Lizenzen:
 		¹Apache License 2.0
 		²MIT license


### PR DESCRIPTION
Es ist zwar schön, dass TuCanMobile als Open Source beworben wird, aber unter welcher Lizenz? 
Bitte Lizenz festlegen und in den Source-Files hinzufügen, damit dies eindeutig ist.
Als ersten Schritt habe ich die Lizenzen für die verwendeten Libs rausgesucht und in der Readme ergänzt - ist bugsense wirklich Proprietär? 
